### PR TITLE
ci: stop the update/release workflows from racing each other

### DIFF
--- a/.github/workflows/release-on-master.yml
+++ b/.github/workflows/release-on-master.yml
@@ -16,8 +16,15 @@ permissions:
 
 jobs:
   create-release:
+    # Pushes to main and the completion of the update workflow both fire for the
+    # same merge, so releases are serialized per product to avoid two runs
+    # racing to create the same tag.
+    concurrency:
+      group: create-release-${{ matrix.tag_prefix }}
+      cancel-in-progress: false
     if: github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -104,7 +104,10 @@ jobs:
       - name: Close superseded automated pull requests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_BRANCH: "${{ matrix.branch_prefix }}-${{ steps.get_version.outputs.version }}"
+          # Only spare the branch this run is about to open a PR for; when the
+          # version is unchanged nothing is spared, so a PR left behind at the
+          # current version (e.g. one that failed to merge) also gets closed.
+          NEW_BRANCH: "${{ steps.check_version.outputs.changed == 'true' && format('{0}-{1}', matrix.branch_prefix, steps.get_version.outputs.version) || '' }}"
           BRANCH_PREFIX: "${{ matrix.branch_prefix }}"
         run: |
           gh pr list --state open --base main --json number,headRefName \
@@ -137,7 +140,9 @@ jobs:
           delete-branch: true
 
       - name: Merge Pull Request
-        if: steps.check_version.outputs.changed == 'true' && steps.cpr.outputs.pull-request-operation == 'created'
+        # 'updated' matters too: a PR whose merge failed earlier is reused by
+        # create-pull-request, and must still be retried instead of stranded.
+        if: steps.check_version.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -99,8 +99,9 @@ jobs:
 
           sed -i "s/\*\*${{ matrix.readme_label }}:\*\* \`.*\`/**${{ matrix.readme_label }}:** \`$VERSION\`/" "$README_PATH"
 
+      # Runs even when the version is unchanged: that is exactly the state in
+      # which an older automated PR is stale and would otherwise stay open.
       - name: Close superseded automated pull requests
-        if: steps.check_version.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_BRANCH: "${{ matrix.branch_prefix }}-${{ steps.get_version.outputs.version }}"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,11 +9,20 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: update-antigravity-packages
+  cancel-in-progress: false
+
 jobs:
   update-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
+      # Both products bump adjacent lines in README.md, so branching them from
+      # the same commit in parallel produces unmergeable PRs. Run one at a time
+      # and always branch from the current tip of main.
+      max-parallel: 1
       matrix:
         include:
           - product_id: ide
@@ -33,6 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Install dependencies
@@ -89,6 +99,22 @@ jobs:
 
           sed -i "s/\*\*${{ matrix.readme_label }}:\*\* \`.*\`/**${{ matrix.readme_label }}:** \`$VERSION\`/" "$README_PATH"
 
+      - name: Close superseded automated pull requests
+        if: steps.check_version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_BRANCH: "${{ matrix.branch_prefix }}-${{ steps.get_version.outputs.version }}"
+          BRANCH_PREFIX: "${{ matrix.branch_prefix }}"
+        run: |
+          gh pr list --state open --base main --json number,headRefName \
+            --repo "${{ github.repository }}" \
+            --jq '.[] | select(.headRefName | startswith(env.BRANCH_PREFIX + "-")) | select(.headRefName != env.NEW_BRANCH) | .number' \
+            | while read -r pr; do
+                echo "Closing superseded PR #$pr"
+                gh pr close "$pr" --delete-branch --repo "${{ github.repository }}" \
+                  --comment "Superseded by a newer automated version bump."
+              done
+
       - name: Create Pull Request
         id: cpr
         if: steps.check_version.outputs.changed == 'true'
@@ -116,5 +142,27 @@ jobs:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           echo "Attempting to merge PR #${PR_NUMBER}"
-          gh pr merge "$PR_NUMBER" --merge --delete-branch --repo "${{ github.repository }}"
-          echo "PR #${PR_NUMBER} merged."
+
+          # GitHub computes mergeability asynchronously, so a freshly created PR
+          # reports UNKNOWN for a few seconds and `gh pr merge` fails on it.
+          for attempt in $(seq 1 10); do
+            STATE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json mergeable --jq .mergeable)
+            echo "Attempt $attempt: mergeable=$STATE"
+
+            case "$STATE" in
+              MERGEABLE)
+                gh pr merge "$PR_NUMBER" --merge --delete-branch --repo "${{ github.repository }}"
+                echo "PR #${PR_NUMBER} merged."
+                exit 0
+                ;;
+              CONFLICTING)
+                echo "PR #${PR_NUMBER} conflicts with main and needs manual resolution." >&2
+                exit 1
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for PR #${PR_NUMBER} to become mergeable." >&2
+          exit 1

--- a/scripts/check-antigravity-version.sh
+++ b/scripts/check-antigravity-version.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 CHANNEL="${1:-${ANTIGRAVITY_CHANNEL:-ide}}"
 DOWNLOAD_PAGE="https://antigravity.google/download"
+CURL_RETRY_OPTS=(--retry 5 --retry-delay 5 --retry-connrefused --connect-timeout 15)
+
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+    CURL_RETRY_OPTS+=(--retry-all-errors)
+fi
 
 TEMP_DIR=$(mktemp -d)
 cleanup() { rm -rf "$TEMP_DIR"; }
@@ -33,7 +38,7 @@ extract_version() {
 configure_channel
 
 DOWNLOAD_URL=$(
-    curl -fsSL --compressed "$DOWNLOAD_PAGE" \
+    curl -fsSL --compressed "${CURL_RETRY_OPTS[@]}" "$DOWNLOAD_PAGE" \
         | grep -oP "$DOWNLOAD_URL_PATTERN" \
         | sort -u \
         | while IFS= read -r url; do
@@ -59,7 +64,7 @@ fi
 
 ARCHIVE_FILE="$TEMP_DIR/antigravity-${CHANNEL//[^a-zA-Z0-9]/-}-${VERSION}.tar.gz"
 echo "Downloading ${PRODUCT_DISPLAY_NAME} from $DOWNLOAD_URL ..." >&2
-if ! curl -fsSL --output "$ARCHIVE_FILE" "$DOWNLOAD_URL"; then
+if ! curl -fsSL "${CURL_RETRY_OPTS[@]}" --output "$ARCHIVE_FILE" "$DOWNLOAD_URL"; then
     echo "Failed to download archive from $DOWNLOAD_URL" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

The red runs in Actions all come from the two matrix products racing, not from the packaging logic:

- **`Merge Pull Request` failed (run 31654846568)** and left PR #39 open with `mergeable_state: dirty`. Both matrix jobs branch from the *same* `github.sha` and both rewrite `README.md` lines 5 and 6 — the two version labels are adjacent lines, so once the 2.0 PR merges, the IDE PR conflicts. Fix: `max-parallel: 1` plus `checkout` with `ref: main`, so the second product branches off the already-updated tip. `gh pr merge` now also waits for GitHub to finish computing `mergeable` (a freshly created PR reports `UNKNOWN` for a few seconds) and fails loudly on `CONFLICTING`.
- **`Get latest version` failed (run 31691132916)**: `curl` had no retry, so one flaky fetch of the download page killed the job. Added `--retry 5 --retry-delay 5 --retry-connrefused --connect-timeout 15` (plus `--retry-all-errors` when the runner's curl supports it) to both the page fetch and the archive download.
- **`Create GitHub Releases on main` failed (run 31813944344)** after 45m stuck in `Set up job` — runner-side hang. Added `timeout-minutes` to both jobs so a hung runner fails in minutes instead of burning 45.
- A merge to `main` fires both `push` and `workflow_run`, so two release runs could try to create the same tag simultaneously; the release job now has a per-product `concurrency` group, and the update workflow has a workflow-level group so overlapping schedules can't interleave.

Also added a step that closes superseded automated PRs for the same `branch_prefix` before opening a new one, so a stuck bump (like #39, still open at 2.5.2 while main is at 2.5.5) doesn't linger forever.

Verified `scripts/check-antigravity-version.sh 2.0` still resolves `2.8.1` with the new curl flags.


Link to Devin session: https://app.devin.ai/sessions/0948af11ad3641b19f09c67b3272842e
Requested by: @BOTOOM
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/botoom/google-antigravity-bin-arch/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->